### PR TITLE
Configure Identity with Oracle-backed stores and role seeding

### DIFF
--- a/src/Sastt.Domain/Identity/SasttRoles.cs
+++ b/src/Sastt.Domain/Identity/SasttRoles.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Sastt.Domain.Identity
+{
+    public static class SasttRoles
+    {
+        public const string Admin = "Admin";
+        public const string Planner = "Planner";
+        public const string Technician = "Technician";
+        public const string TrainingOfficer = "TrainingOfficer";
+        public const string Auditor = "Auditor";
+        public const string Viewer = "Viewer";
+    }
+}

--- a/src/Sastt.Domain/Sastt.Domain.csproj
+++ b/src/Sastt.Domain/Sastt.Domain.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/Sastt.Infrastructure/Identity/ApplicationDbContext.cs
+++ b/src/Sastt.Infrastructure/Identity/ApplicationDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Sastt.Infrastructure.Identity
+{
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+    }
+}

--- a/src/Sastt.Infrastructure/Identity/ApplicationUser.cs
+++ b/src/Sastt.Infrastructure/Identity/ApplicationUser.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Sastt.Infrastructure.Identity
+{
+    public class ApplicationUser : IdentityUser
+    {
+    }
+}

--- a/src/Sastt.Infrastructure/Identity/DatabaseInitializer.cs
+++ b/src/Sastt.Infrastructure/Identity/DatabaseInitializer.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Sastt.Domain.Identity;
+
+namespace Sastt.Infrastructure.Identity
+{
+    public class DatabaseInitializer : IDatabaseInitializer
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly RoleManager<IdentityRole> _roleManager;
+
+        public DatabaseInitializer(UserManager<ApplicationUser> userManager, RoleManager<IdentityRole> roleManager)
+        {
+            _userManager = userManager;
+            _roleManager = roleManager;
+        }
+
+        public async Task SeedAsync()
+        {
+            var roles = new[]
+            {
+                SasttRoles.Admin,
+                SasttRoles.Planner,
+                SasttRoles.Technician,
+                SasttRoles.TrainingOfficer,
+                SasttRoles.Auditor,
+                SasttRoles.Viewer
+            };
+
+            foreach (var role in roles)
+            {
+                if (!await _roleManager.RoleExistsAsync(role))
+                {
+                    await _roleManager.CreateAsync(new IdentityRole(role));
+                }
+            }
+
+            var adminEmail = "admin@sastt.local";
+            var adminUser = await _userManager.FindByEmailAsync(adminEmail);
+            if (adminUser == null)
+            {
+                adminUser = new ApplicationUser { UserName = adminEmail, Email = adminEmail, EmailConfirmed = true };
+                await _userManager.CreateAsync(adminUser, "Passw0rd!");
+            }
+
+            await _userManager.AddToRolesAsync(adminUser, roles);
+        }
+    }
+}

--- a/src/Sastt.Infrastructure/Identity/IDatabaseInitializer.cs
+++ b/src/Sastt.Infrastructure/Identity/IDatabaseInitializer.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Sastt.Infrastructure.Identity
+{
+    public interface IDatabaseInitializer
+    {
+        Task SeedAsync();
+    }
+}

--- a/src/Sastt.Infrastructure/Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Sastt.Infrastructure/Identity/IdentityServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Sastt.Infrastructure.Identity
+{
+    public static class IdentityServiceCollectionExtensions
+    {
+        public static IServiceCollection AddIdentityInfrastructure(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseOracle(configuration.GetConnectionString("DefaultConnection")));
+
+            services.AddIdentity<ApplicationUser, IdentityRole>()
+                .AddEntityFrameworkStores<ApplicationDbContext>()
+                .AddDefaultTokenProviders();
+
+            services.AddTransient<IDatabaseInitializer, DatabaseInitializer>();
+            return services;
+        }
+    }
+}

--- a/src/Sastt.Infrastructure/Sastt.Infrastructure.csproj
+++ b/src/Sastt.Infrastructure/Sastt.Infrastructure.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Oracle.EntityFrameworkCore" Version="8.21.35" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Sastt.Domain/Sastt.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Sastt.Web/Controllers/AdminController.cs
+++ b/src/Sastt.Web/Controllers/AdminController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Sastt.Domain.Identity;
+
+namespace Sastt.Web.Controllers
+{
+    [Authorize(Roles = SasttRoles.Admin)]
+    [Route("admin")]
+    public class AdminController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index() => Content("Admin area");
+    }
+}

--- a/src/Sastt.Web/Controllers/AuditController.cs
+++ b/src/Sastt.Web/Controllers/AuditController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Sastt.Domain.Identity;
+
+namespace Sastt.Web.Controllers
+{
+    [Authorize(Roles = SasttRoles.Auditor)]
+    [Route("audit")]
+    public class AuditController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index() => Content("Audit area");
+    }
+}

--- a/src/Sastt.Web/Controllers/PlannerController.cs
+++ b/src/Sastt.Web/Controllers/PlannerController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Sastt.Domain.Identity;
+
+namespace Sastt.Web.Controllers
+{
+    [Authorize(Roles = SasttRoles.Planner)]
+    [Route("planner")]
+    public class PlannerController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index() => Content("Planner area");
+    }
+}

--- a/src/Sastt.Web/Controllers/TechnicianController.cs
+++ b/src/Sastt.Web/Controllers/TechnicianController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Sastt.Domain.Identity;
+
+namespace Sastt.Web.Controllers
+{
+    [Authorize(Roles = SasttRoles.Technician)]
+    [Route("technician")]
+    public class TechnicianController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index() => Content("Technician area");
+    }
+}

--- a/src/Sastt.Web/Controllers/TrainingController.cs
+++ b/src/Sastt.Web/Controllers/TrainingController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Sastt.Domain.Identity;
+
+namespace Sastt.Web.Controllers
+{
+    [Authorize(Roles = SasttRoles.TrainingOfficer)]
+    [Route("training")]
+    public class TrainingController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index() => Content("Training officer area");
+    }
+}

--- a/src/Sastt.Web/Controllers/ViewerController.cs
+++ b/src/Sastt.Web/Controllers/ViewerController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Sastt.Domain.Identity;
+
+namespace Sastt.Web.Controllers
+{
+    [Authorize(Roles = SasttRoles.Viewer)]
+    [Route("viewer")]
+    public class ViewerController : Controller
+    {
+        [HttpGet("")]
+        public IActionResult Index() => Content("Viewer area");
+    }
+}

--- a/src/Sastt.Web/Program.cs
+++ b/src/Sastt.Web/Program.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Sastt.Infrastructure.Identity;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllersWithViews();
+builder.Services.AddIdentityInfrastructure(builder.Configuration);
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var initializer = scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>();
+    await initializer.SeedAsync();
+}
+
+app.MapControllers();
+
+app.Run();

--- a/src/Sastt.Web/Sastt.Web.csproj
+++ b/src/Sastt.Web/Sastt.Web.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Sastt.Infrastructure/Sastt.Infrastructure.csproj" />
+    <ProjectReference Include="../Sastt.Domain/Sastt.Domain.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add ASP.NET Identity configuration with Oracle EF Core stores
- define application roles and seed default admin user
- protect example controllers with role-based authorization

## Testing
- `dotnet build` *(fails: command not found)*

