### PR TITLE
Add weather client with caching and dashboard display

### DIFF
--- a/src/Sastt.Application/Weather/IWeatherClient.cs
+++ b/src/Sastt.Application/Weather/IWeatherClient.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sastt.Application.Weather;
+
+public interface IWeatherClient
+{
+    Task<WeatherSnapshot> GetWeatherAsync(string baseCode, CancellationToken cancellationToken = default);
+}

--- a/src/Sastt.Application/Weather/Queries/GetWeatherSnapshotQuery.cs
+++ b/src/Sastt.Application/Weather/Queries/GetWeatherSnapshotQuery.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Sastt.Application.Weather.Queries;
+
+public class GetWeatherSnapshotQuery
+{
+    private readonly IWeatherClient _client;
+    private readonly IMemoryCache _cache;
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(15);
+
+    public GetWeatherSnapshotQuery(IWeatherClient client, IMemoryCache cache)
+    {
+        _client = client;
+        _cache = cache;
+    }
+
+    public async Task<WeatherSnapshot> ExecuteAsync(string baseCode, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = $"weather:{baseCode}";
+        if (_cache.TryGetValue(cacheKey, out WeatherSnapshot snapshot))
+        {
+            return snapshot;
+        }
+
+        snapshot = await _client.GetWeatherAsync(baseCode, cancellationToken);
+        _cache.Set(cacheKey, snapshot, CacheDuration);
+        return snapshot;
+    }
+}

--- a/src/Sastt.Application/Weather/WeatherSnapshot.cs
+++ b/src/Sastt.Application/Weather/WeatherSnapshot.cs
@@ -1,0 +1,7 @@
+namespace Sastt.Application.Weather;
+
+public record WeatherSnapshot(
+    string BaseCode,
+    decimal TemperatureC,
+    string Conditions,
+    DateTime RetrievedAt);

--- a/src/Sastt.Infrastructure/Services/WeatherClient.cs
+++ b/src/Sastt.Infrastructure/Services/WeatherClient.cs
@@ -1,0 +1,40 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Sastt.Application.Weather;
+
+namespace Sastt.Infrastructure.Services;
+
+public class WeatherClient : IWeatherClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+
+    public WeatherClient(HttpClient httpClient, IConfiguration config)
+    {
+        _httpClient = httpClient;
+        _apiKey = config["WEATHER__APIKEY"] ?? string.Empty;
+    }
+
+    public async Task<WeatherSnapshot> GetWeatherAsync(string baseCode, CancellationToken cancellationToken = default)
+    {
+        var url = $"https://api.open-meteo.com/v1/forecast?latitude=0&longitude=0&current_weather=true&apikey={_apiKey}";
+        var result = await _httpClient.GetFromJsonAsync<OpenMeteoResponse>(url, cancellationToken);
+        var temp = result?.CurrentWeather?.Temperature ?? 0m;
+        var cond = result?.CurrentWeather?.WeatherCode?.ToString() ?? "Unknown";
+        return new WeatherSnapshot(baseCode, temp, cond, DateTime.UtcNow);
+    }
+
+    private sealed class OpenMeteoResponse
+    {
+        public CurrentWeatherInfo? CurrentWeather { get; set; }
+    }
+
+    private sealed class CurrentWeatherInfo
+    {
+        public decimal Temperature { get; set; }
+        public int WeatherCode { get; set; }
+    }
+}

--- a/src/Sastt.Web/Pages/Dashboard/Index.cshtml
+++ b/src/Sastt.Web/Pages/Dashboard/Index.cshtml
@@ -1,0 +1,15 @@
+@page
+@model Sastt.Web.Pages.Dashboard.IndexModel
+
+<h2>Weather Snapshot</h2>
+@if (Model.Snapshot is not null)
+{
+    <p>Base: @Model.Snapshot.BaseCode</p>
+    <p>Temperature: @Model.Snapshot.TemperatureC &deg;C</p>
+    <p>Conditions: @Model.Snapshot.Conditions</p>
+    <p>Retrieved: @Model.Snapshot.RetrievedAt</p>
+}
+else
+{
+    <p>No data available.</p>
+}

--- a/src/Sastt.Web/Pages/Dashboard/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Dashboard/Index.cshtml.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Sastt.Application.Weather;
+using Sastt.Application.Weather.Queries;
+
+namespace Sastt.Web.Pages.Dashboard;
+
+public class IndexModel : PageModel
+{
+    private readonly GetWeatherSnapshotQuery _query;
+    public WeatherSnapshot? Snapshot { get; private set; }
+
+    public IndexModel(GetWeatherSnapshotQuery query)
+    {
+        _query = query;
+    }
+
+    public async Task OnGet()
+    {
+        Snapshot = await _query.ExecuteAsync("YSSY");
+    }
+}

--- a/src/Sastt.Web/Program.cs
+++ b/src/Sastt.Web/Program.cs
@@ -1,0 +1,16 @@
+using Sastt.Application.Weather;
+using Sastt.Application.Weather.Queries;
+using Sastt.Infrastructure.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddMemoryCache();
+builder.Services.AddHttpClient<IWeatherClient, WeatherClient>();
+builder.Services.AddScoped<GetWeatherSnapshotQuery>();
+
+var app = builder.Build();
+
+app.MapRazorPages();
+
+app.Run();


### PR DESCRIPTION
## Summary
- introduce WeatherClient leveraging HttpClient and API key configuration
- add weather snapshot query with 15-minute in-memory caching
- surface cached weather data on dashboard page

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a7d4deb48329aac8ee30ae60fe94