### PR TITLE
Add domain event infrastructure for core entities

### DIFF
--- a/src/Sastt.Domain/Entities/Base.cs
+++ b/src/Sastt.Domain/Entities/Base.cs
@@ -1,3 +1,5 @@
+using Sastt.Domain.Events;
+
 namespace Sastt.Domain.Entities;
 
 public abstract class Base
@@ -5,5 +7,10 @@ public abstract class Base
     public Guid Id { get; set; } = Guid.NewGuid();
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
-    public List<object> DomainEvents { get; } = new();
+
+    private readonly List<IDomainEvent> _domainEvents = new();
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    protected void AddDomainEvent(IDomainEvent domainEvent) => _domainEvents.Add(domainEvent);
+    public void ClearDomainEvents() => _domainEvents.Clear();
 }

--- a/src/Sastt.Domain/Entities/TrainingSession.cs
+++ b/src/Sastt.Domain/Entities/TrainingSession.cs
@@ -13,7 +13,7 @@ public class TrainingSession : Base
         if (!Completed)
         {
             Completed = true;
-            DomainEvents.Add(new TrainingSessionCompletedEvent(Id, PilotId));
+            AddDomainEvent(new TrainingSessionCompletedEvent(Id, PilotId));
         }
     }
 }

--- a/src/Sastt.Domain/Entities/WorkOrder.cs
+++ b/src/Sastt.Domain/Entities/WorkOrder.cs
@@ -15,7 +15,7 @@ public class WorkOrder : Base
         if (newStatus != Status)
         {
             Status = newStatus;
-            DomainEvents.Add(new WorkOrderStatusChangedEvent(Id, newStatus));
+            AddDomainEvent(new WorkOrderStatusChangedEvent(Id, newStatus));
         }
     }
 }

--- a/src/Sastt.Domain/Events/IDomainEvent.cs
+++ b/src/Sastt.Domain/Events/IDomainEvent.cs
@@ -1,0 +1,6 @@
+namespace Sastt.Domain.Events;
+
+public interface IDomainEvent
+{
+}
+

--- a/src/Sastt.Domain/Events/TrainingSessionCompletedEvent.cs
+++ b/src/Sastt.Domain/Events/TrainingSessionCompletedEvent.cs
@@ -1,3 +1,3 @@
 namespace Sastt.Domain.Events;
 
-public record TrainingSessionCompletedEvent(Guid TrainingSessionId, Guid PilotId);
+public record TrainingSessionCompletedEvent(Guid TrainingSessionId, Guid PilotId) : IDomainEvent;

--- a/src/Sastt.Domain/Events/WorkOrderStatusChangedEvent.cs
+++ b/src/Sastt.Domain/Events/WorkOrderStatusChangedEvent.cs
@@ -2,4 +2,4 @@ using Sastt.Domain.Enums;
 
 namespace Sastt.Domain.Events;
 
-public record WorkOrderStatusChangedEvent(Guid WorkOrderId, WorkOrderStatus NewStatus);
+public record WorkOrderStatusChangedEvent(Guid WorkOrderId, WorkOrderStatus NewStatus) : IDomainEvent;


### PR DESCRIPTION
## Summary
- introduce a simple `IDomainEvent` marker
- track and raise domain events in `Base`, `WorkOrder`, and `TrainingSession`

## Testing
- `dotnet test` *(fails: command not found)*
