### PR TITLE
feat: add MediatR pipeline and CRUD commands

### DIFF
--- a/src/Sastt.Application/Aircraft/Commands/Command.cs
+++ b/src/Sastt.Application/Aircraft/Commands/Command.cs
@@ -1,0 +1,86 @@
+using FluentValidation;
+using MediatR;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.Aircraft.Commands;
+
+public record CreateAircraftCommand(string TailNumber, string Base) : IRequest<string>;
+
+public class CreateAircraftCommandValidator : AbstractValidator<CreateAircraftCommand>
+{
+    public CreateAircraftCommandValidator()
+    {
+        RuleFor(x => x.TailNumber).NotEmpty();
+        RuleFor(x => x.Base).NotEmpty();
+    }
+}
+
+public class CreateAircraftCommandHandler : IRequestHandler<CreateAircraftCommand, string>
+{
+    private readonly IApplicationDbContext _context;
+    public CreateAircraftCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<string> Handle(CreateAircraftCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new Sastt.Domain.Aircraft { TailNumber = request.TailNumber, Base = request.Base };
+        _context.Aircraft.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.TailNumber;
+    }
+}
+
+public record UpdateAircraftCommand(string TailNumber, string Base) : IRequest;
+
+public class UpdateAircraftCommandValidator : AbstractValidator<UpdateAircraftCommand>
+{
+    public UpdateAircraftCommandValidator()
+    {
+        RuleFor(x => x.TailNumber).NotEmpty();
+        RuleFor(x => x.Base).NotEmpty();
+    }
+}
+
+public class UpdateAircraftCommandHandler : IRequestHandler<UpdateAircraftCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public UpdateAircraftCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(UpdateAircraftCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Aircraft.FindAsync(new object[] { request.TailNumber }, cancellationToken);
+        if (entity is null)
+        {
+            throw new KeyNotFoundException($"Aircraft {request.TailNumber} not found");
+        }
+        entity.Base = request.Base;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public record DeleteAircraftCommand(string TailNumber) : IRequest;
+
+public class DeleteAircraftCommandValidator : AbstractValidator<DeleteAircraftCommand>
+{
+    public DeleteAircraftCommandValidator()
+    {
+        RuleFor(x => x.TailNumber).NotEmpty();
+    }
+}
+
+public class DeleteAircraftCommandHandler : IRequestHandler<DeleteAircraftCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public DeleteAircraftCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(DeleteAircraftCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Aircraft.FindAsync(new object[] { request.TailNumber }, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+        _context.Aircraft.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Sastt.Application/Aircraft/Queries/Query.cs
+++ b/src/Sastt.Application/Aircraft/Queries/Query.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.Aircraft.Queries;
+
+public record GetAircraftByTailNumberQuery(string TailNumber) : IRequest<Sastt.Domain.Aircraft?>;
+
+public class GetAircraftByTailNumberQueryHandler : IRequestHandler<GetAircraftByTailNumberQuery, Sastt.Domain.Aircraft?>
+{
+    private readonly IApplicationDbContext _context;
+    public GetAircraftByTailNumberQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<Sastt.Domain.Aircraft?> Handle(GetAircraftByTailNumberQuery request, CancellationToken cancellationToken)
+        => await _context.Aircraft.FindAsync(new object[] { request.TailNumber }, cancellationToken);
+}
+
+public record GetAircraftListQuery() : IRequest<List<Sastt.Domain.Aircraft>>;
+
+public class GetAircraftListQueryHandler : IRequestHandler<GetAircraftListQuery, List<Sastt.Domain.Aircraft>>
+{
+    private readonly IApplicationDbContext _context;
+    public GetAircraftListQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<List<Sastt.Domain.Aircraft>> Handle(GetAircraftListQuery request, CancellationToken cancellationToken)
+        => await _context.Aircraft.ToListAsync(cancellationToken);
+}

--- a/src/Sastt.Application/Common/Behaviors/LoggingBehavior.cs
+++ b/src/Sastt.Application/Common/Behaviors/LoggingBehavior.cs
@@ -1,0 +1,23 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Sastt.Application.Common.Behaviors;
+
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly ILogger<TRequest> _logger;
+
+    public LoggingBehavior(ILogger<TRequest> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling {Request}", typeof(TRequest).Name);
+        var response = await next();
+        _logger.LogInformation("Handled {Request}", typeof(TRequest).Name);
+        return response;
+    }
+}

--- a/src/Sastt.Application/Common/Behaviors/ValidationBehavior.cs
+++ b/src/Sastt.Application/Common/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using MediatR;
+
+namespace Sastt.Application.Common.Behaviors;
+
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (_validators.Any())
+        {
+            var context = new ValidationContext<TRequest>(request);
+            var failures = (await Task.WhenAll(_validators.Select(v => v.ValidateAsync(context, cancellationToken))))
+                .SelectMany(r => r.Errors)
+                .Where(f => f is not null)
+                .ToList();
+            if (failures.Count != 0)
+            {
+                throw new ValidationException(failures);
+            }
+        }
+        return await next();
+    }
+}

--- a/src/Sastt.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/Sastt.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain;
+
+namespace Sastt.Application.Common.Interfaces;
+
+public interface IApplicationDbContext
+{
+    DbSet<Aircraft> Aircraft { get; }
+    DbSet<WorkOrder> WorkOrders { get; }
+    DbSet<WorkOrderTask> WorkOrderTasks { get; }
+    DbSet<Defect> Defects { get; }
+    DbSet<Pilot> Pilots { get; }
+    DbSet<TrainingSession> TrainingSessions { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/src/Sastt.Application/Defects/Commands/Command.cs
+++ b/src/Sastt.Application/Defects/Commands/Command.cs
@@ -1,0 +1,88 @@
+using FluentValidation;
+using MediatR;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.Defects.Commands;
+
+public record CreateDefectCommand(int WorkOrderId, string? Severity, string? Description) : IRequest<int>;
+
+public class CreateDefectCommandValidator : AbstractValidator<CreateDefectCommand>
+{
+    public CreateDefectCommandValidator()
+    {
+        RuleFor(x => x.WorkOrderId).GreaterThan(0);
+    }
+}
+
+public class CreateDefectCommandHandler : IRequestHandler<CreateDefectCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+    public CreateDefectCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<int> Handle(CreateDefectCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new Defect { WorkOrderId = request.WorkOrderId, Severity = request.Severity, Description = request.Description };
+        _context.Defects.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}
+
+public record UpdateDefectCommand(int Id, int WorkOrderId, string? Severity, string? Description, bool IsClosed) : IRequest;
+
+public class UpdateDefectCommandValidator : AbstractValidator<UpdateDefectCommand>
+{
+    public UpdateDefectCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+        RuleFor(x => x.WorkOrderId).GreaterThan(0);
+    }
+}
+
+public class UpdateDefectCommandHandler : IRequestHandler<UpdateDefectCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public UpdateDefectCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(UpdateDefectCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Defects.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            throw new KeyNotFoundException($"Defect {request.Id} not found");
+        }
+        entity.WorkOrderId = request.WorkOrderId;
+        entity.Severity = request.Severity;
+        entity.Description = request.Description;
+        entity.IsClosed = request.IsClosed;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public record DeleteDefectCommand(int Id) : IRequest;
+
+public class DeleteDefectCommandValidator : AbstractValidator<DeleteDefectCommand>
+{
+    public DeleteDefectCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+
+public class DeleteDefectCommandHandler : IRequestHandler<DeleteDefectCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public DeleteDefectCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(DeleteDefectCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Defects.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+        _context.Defects.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Sastt.Application/Defects/Queries/Query.cs
+++ b/src/Sastt.Application/Defects/Queries/Query.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.Defects.Queries;
+
+public record GetDefectByIdQuery(int Id) : IRequest<Defect?>;
+
+public class GetDefectByIdQueryHandler : IRequestHandler<GetDefectByIdQuery, Defect?>
+{
+    private readonly IApplicationDbContext _context;
+    public GetDefectByIdQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<Defect?> Handle(GetDefectByIdQuery request, CancellationToken cancellationToken)
+        => await _context.Defects.FindAsync(new object[] { request.Id }, cancellationToken);
+}
+
+public record GetDefectListQuery() : IRequest<List<Defect>>;
+
+public class GetDefectListQueryHandler : IRequestHandler<GetDefectListQuery, List<Defect>>
+{
+    private readonly IApplicationDbContext _context;
+    public GetDefectListQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<List<Defect>> Handle(GetDefectListQuery request, CancellationToken cancellationToken)
+        => await _context.Defects.ToListAsync(cancellationToken);
+}

--- a/src/Sastt.Application/DependencyInjection.cs
+++ b/src/Sastt.Application/DependencyInjection.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Sastt.Application.Common.Behaviors;
+
+namespace Sastt.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
+        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+        return services;
+    }
+}

--- a/src/Sastt.Application/Pilots/Commands/Command.cs
+++ b/src/Sastt.Application/Pilots/Commands/Command.cs
@@ -1,0 +1,85 @@
+using FluentValidation;
+using MediatR;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.Pilots.Commands;
+
+public record CreatePilotCommand(string Name) : IRequest<int>;
+
+public class CreatePilotCommandValidator : AbstractValidator<CreatePilotCommand>
+{
+    public CreatePilotCommandValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty();
+    }
+}
+
+public class CreatePilotCommandHandler : IRequestHandler<CreatePilotCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+    public CreatePilotCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<int> Handle(CreatePilotCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new Pilot { Name = request.Name };
+        _context.Pilots.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}
+
+public record UpdatePilotCommand(int Id, string Name) : IRequest;
+
+public class UpdatePilotCommandValidator : AbstractValidator<UpdatePilotCommand>
+{
+    public UpdatePilotCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+        RuleFor(x => x.Name).NotEmpty();
+    }
+}
+
+public class UpdatePilotCommandHandler : IRequestHandler<UpdatePilotCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public UpdatePilotCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(UpdatePilotCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Pilots.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            throw new KeyNotFoundException($"Pilot {request.Id} not found");
+        }
+        entity.Name = request.Name;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public record DeletePilotCommand(int Id) : IRequest;
+
+public class DeletePilotCommandValidator : AbstractValidator<DeletePilotCommand>
+{
+    public DeletePilotCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+
+public class DeletePilotCommandHandler : IRequestHandler<DeletePilotCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public DeletePilotCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(DeletePilotCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Pilots.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+        _context.Pilots.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Sastt.Application/Pilots/Queries/Query.cs
+++ b/src/Sastt.Application/Pilots/Queries/Query.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.Pilots.Queries;
+
+public record GetPilotByIdQuery(int Id) : IRequest<Pilot?>;
+
+public class GetPilotByIdQueryHandler : IRequestHandler<GetPilotByIdQuery, Pilot?>
+{
+    private readonly IApplicationDbContext _context;
+    public GetPilotByIdQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<Pilot?> Handle(GetPilotByIdQuery request, CancellationToken cancellationToken)
+        => await _context.Pilots.FindAsync(new object[] { request.Id }, cancellationToken);
+}
+
+public record GetPilotListQuery() : IRequest<List<Pilot>>;
+
+public class GetPilotListQueryHandler : IRequestHandler<GetPilotListQuery, List<Pilot>>
+{
+    private readonly IApplicationDbContext _context;
+    public GetPilotListQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<List<Pilot>> Handle(GetPilotListQuery request, CancellationToken cancellationToken)
+        => await _context.Pilots.ToListAsync(cancellationToken);
+}

--- a/src/Sastt.Application/Sastt.Application.csproj
+++ b/src/Sastt.Application/Sastt.Application.csproj
@@ -7,4 +7,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Sastt.Domain\Sastt.Domain.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Sastt.Application/TrainingSessions/Commands/Command.cs
+++ b/src/Sastt.Application/TrainingSessions/Commands/Command.cs
@@ -1,0 +1,89 @@
+using FluentValidation;
+using MediatR;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.TrainingSessions.Commands;
+
+public record CreateTrainingSessionCommand(int PilotId, DateTime Date, int Hours) : IRequest<int>;
+
+public class CreateTrainingSessionCommandValidator : AbstractValidator<CreateTrainingSessionCommand>
+{
+    public CreateTrainingSessionCommandValidator()
+    {
+        RuleFor(x => x.PilotId).GreaterThan(0);
+        RuleFor(x => x.Hours).GreaterThan(0);
+    }
+}
+
+public class CreateTrainingSessionCommandHandler : IRequestHandler<CreateTrainingSessionCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+    public CreateTrainingSessionCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<int> Handle(CreateTrainingSessionCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new TrainingSession { PilotId = request.PilotId, Date = request.Date, Hours = request.Hours };
+        _context.TrainingSessions.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}
+
+public record UpdateTrainingSessionCommand(int Id, int PilotId, DateTime Date, int Hours) : IRequest;
+
+public class UpdateTrainingSessionCommandValidator : AbstractValidator<UpdateTrainingSessionCommand>
+{
+    public UpdateTrainingSessionCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+        RuleFor(x => x.PilotId).GreaterThan(0);
+        RuleFor(x => x.Hours).GreaterThan(0);
+    }
+}
+
+public class UpdateTrainingSessionCommandHandler : IRequestHandler<UpdateTrainingSessionCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public UpdateTrainingSessionCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(UpdateTrainingSessionCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.TrainingSessions.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            throw new KeyNotFoundException($"TrainingSession {request.Id} not found");
+        }
+        entity.PilotId = request.PilotId;
+        entity.Date = request.Date;
+        entity.Hours = request.Hours;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public record DeleteTrainingSessionCommand(int Id) : IRequest;
+
+public class DeleteTrainingSessionCommandValidator : AbstractValidator<DeleteTrainingSessionCommand>
+{
+    public DeleteTrainingSessionCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+
+public class DeleteTrainingSessionCommandHandler : IRequestHandler<DeleteTrainingSessionCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public DeleteTrainingSessionCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(DeleteTrainingSessionCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.TrainingSessions.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+        _context.TrainingSessions.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Sastt.Application/TrainingSessions/Queries/Query.cs
+++ b/src/Sastt.Application/TrainingSessions/Queries/Query.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.TrainingSessions.Queries;
+
+public record GetTrainingSessionByIdQuery(int Id) : IRequest<TrainingSession?>;
+
+public class GetTrainingSessionByIdQueryHandler : IRequestHandler<GetTrainingSessionByIdQuery, TrainingSession?>
+{
+    private readonly IApplicationDbContext _context;
+    public GetTrainingSessionByIdQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<TrainingSession?> Handle(GetTrainingSessionByIdQuery request, CancellationToken cancellationToken)
+        => await _context.TrainingSessions.FindAsync(new object[] { request.Id }, cancellationToken);
+}
+
+public record GetTrainingSessionListQuery() : IRequest<List<TrainingSession>>;
+
+public class GetTrainingSessionListQueryHandler : IRequestHandler<GetTrainingSessionListQuery, List<TrainingSession>>
+{
+    private readonly IApplicationDbContext _context;
+    public GetTrainingSessionListQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<List<TrainingSession>> Handle(GetTrainingSessionListQuery request, CancellationToken cancellationToken)
+        => await _context.TrainingSessions.ToListAsync(cancellationToken);
+}

--- a/src/Sastt.Application/WorkOrderTasks/Commands/Command.cs
+++ b/src/Sastt.Application/WorkOrderTasks/Commands/Command.cs
@@ -1,0 +1,87 @@
+using FluentValidation;
+using MediatR;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.WorkOrderTasks.Commands;
+
+public record CreateWorkOrderTaskCommand(int WorkOrderId, string Description) : IRequest<int>;
+
+public class CreateWorkOrderTaskCommandValidator : AbstractValidator<CreateWorkOrderTaskCommand>
+{
+    public CreateWorkOrderTaskCommandValidator()
+    {
+        RuleFor(x => x.WorkOrderId).GreaterThan(0);
+        RuleFor(x => x.Description).NotEmpty();
+    }
+}
+
+public class CreateWorkOrderTaskCommandHandler : IRequestHandler<CreateWorkOrderTaskCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+    public CreateWorkOrderTaskCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<int> Handle(CreateWorkOrderTaskCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new WorkOrderTask { WorkOrderId = request.WorkOrderId, Description = request.Description };
+        _context.WorkOrderTasks.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}
+
+public record UpdateWorkOrderTaskCommand(int Id, string Description, bool IsCompleted) : IRequest;
+
+public class UpdateWorkOrderTaskCommandValidator : AbstractValidator<UpdateWorkOrderTaskCommand>
+{
+    public UpdateWorkOrderTaskCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+        RuleFor(x => x.Description).NotEmpty();
+    }
+}
+
+public class UpdateWorkOrderTaskCommandHandler : IRequestHandler<UpdateWorkOrderTaskCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public UpdateWorkOrderTaskCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(UpdateWorkOrderTaskCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.WorkOrderTasks.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            throw new KeyNotFoundException($"Task {request.Id} not found");
+        }
+        entity.Description = request.Description;
+        entity.IsCompleted = request.IsCompleted;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public record DeleteWorkOrderTaskCommand(int Id) : IRequest;
+
+public class DeleteWorkOrderTaskCommandValidator : AbstractValidator<DeleteWorkOrderTaskCommand>
+{
+    public DeleteWorkOrderTaskCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+
+public class DeleteWorkOrderTaskCommandHandler : IRequestHandler<DeleteWorkOrderTaskCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public DeleteWorkOrderTaskCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(DeleteWorkOrderTaskCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.WorkOrderTasks.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+        _context.WorkOrderTasks.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Sastt.Application/WorkOrderTasks/Queries/Query.cs
+++ b/src/Sastt.Application/WorkOrderTasks/Queries/Query.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.WorkOrderTasks.Queries;
+
+public record GetWorkOrderTaskByIdQuery(int Id) : IRequest<WorkOrderTask?>;
+
+public class GetWorkOrderTaskByIdQueryHandler : IRequestHandler<GetWorkOrderTaskByIdQuery, WorkOrderTask?>
+{
+    private readonly IApplicationDbContext _context;
+    public GetWorkOrderTaskByIdQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<WorkOrderTask?> Handle(GetWorkOrderTaskByIdQuery request, CancellationToken cancellationToken)
+        => await _context.WorkOrderTasks.FindAsync(new object[] { request.Id }, cancellationToken);
+}
+
+public record GetWorkOrderTaskListQuery() : IRequest<List<WorkOrderTask>>;
+
+public class GetWorkOrderTaskListQueryHandler : IRequestHandler<GetWorkOrderTaskListQuery, List<WorkOrderTask>>
+{
+    private readonly IApplicationDbContext _context;
+    public GetWorkOrderTaskListQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<List<WorkOrderTask>> Handle(GetWorkOrderTaskListQuery request, CancellationToken cancellationToken)
+        => await _context.WorkOrderTasks.ToListAsync(cancellationToken);
+}

--- a/src/Sastt.Application/WorkOrders/Commands/Command.cs
+++ b/src/Sastt.Application/WorkOrders/Commands/Command.cs
@@ -1,0 +1,87 @@
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.WorkOrders.Commands;
+
+public record CreateWorkOrderCommand(string Title, int AircraftId) : IRequest<int>;
+
+public class CreateWorkOrderCommandValidator : AbstractValidator<CreateWorkOrderCommand>
+{
+    public CreateWorkOrderCommandValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty();
+    }
+}
+
+public class CreateWorkOrderCommandHandler : IRequestHandler<CreateWorkOrderCommand, int>
+{
+    private readonly IApplicationDbContext _context;
+    public CreateWorkOrderCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<int> Handle(CreateWorkOrderCommand request, CancellationToken cancellationToken)
+    {
+        var entity = new WorkOrder { Title = request.Title, AircraftId = request.AircraftId };
+        _context.WorkOrders.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entity.Id;
+    }
+}
+
+public record UpdateWorkOrderCommand(int Id, string Title, int AircraftId) : IRequest;
+
+public class UpdateWorkOrderCommandValidator : AbstractValidator<UpdateWorkOrderCommand>
+{
+    public UpdateWorkOrderCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+        RuleFor(x => x.Title).NotEmpty();
+    }
+}
+
+public class UpdateWorkOrderCommandHandler : IRequestHandler<UpdateWorkOrderCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public UpdateWorkOrderCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(UpdateWorkOrderCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.WorkOrders.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            throw new KeyNotFoundException($"WorkOrder {request.Id} not found");
+        }
+        entity.Title = request.Title;
+        entity.AircraftId = request.AircraftId;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}
+
+public record DeleteWorkOrderCommand(int Id) : IRequest;
+
+public class DeleteWorkOrderCommandValidator : AbstractValidator<DeleteWorkOrderCommand>
+{
+    public DeleteWorkOrderCommandValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+
+public class DeleteWorkOrderCommandHandler : IRequestHandler<DeleteWorkOrderCommand>
+{
+    private readonly IApplicationDbContext _context;
+    public DeleteWorkOrderCommandHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task Handle(DeleteWorkOrderCommand request, CancellationToken cancellationToken)
+    {
+        var entity = await _context.WorkOrders.FindAsync(new object[] { request.Id }, cancellationToken);
+        if (entity is null)
+        {
+            return;
+        }
+        _context.WorkOrders.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Sastt.Application/WorkOrders/Queries/Query.cs
+++ b/src/Sastt.Application/WorkOrders/Queries/Query.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Common.Interfaces;
+using Sastt.Domain;
+
+namespace Sastt.Application.WorkOrders.Queries;
+
+public record GetWorkOrderByIdQuery(int Id) : IRequest<WorkOrder?>;
+
+public class GetWorkOrderByIdQueryHandler : IRequestHandler<GetWorkOrderByIdQuery, WorkOrder?>
+{
+    private readonly IApplicationDbContext _context;
+    public GetWorkOrderByIdQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<WorkOrder?> Handle(GetWorkOrderByIdQuery request, CancellationToken cancellationToken)
+        => await _context.WorkOrders.FindAsync(new object[] { request.Id }, cancellationToken);
+}
+
+public record GetWorkOrderListQuery() : IRequest<List<WorkOrder>>;
+
+public class GetWorkOrderListQueryHandler : IRequestHandler<GetWorkOrderListQuery, List<WorkOrder>>
+{
+    private readonly IApplicationDbContext _context;
+    public GetWorkOrderListQueryHandler(IApplicationDbContext context) => _context = context;
+
+    public async Task<List<WorkOrder>> Handle(GetWorkOrderListQuery request, CancellationToken cancellationToken)
+        => await _context.WorkOrders.ToListAsync(cancellationToken);
+}


### PR DESCRIPTION
## Summary
- add MediatR & FluentValidation packages to Application layer
- implement CRUD commands/queries for Aircraft, WorkOrders, Tasks, Defects, Pilots and TrainingSessions
- register logging and validation pipeline behaviors

## Testing
- `dotnet build src/Sastt.Application/Sastt.Application.csproj` *(fails: command not found)*

