### PR TITLE
Add Razor pages and DI setup for core entities

### DIFF
--- a/src/Sastt.Application/ServiceCollectionExtensions.cs
+++ b/src/Sastt.Application/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Sastt.Application.Weather.Queries;
+
+namespace Sastt.Application;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddScoped<GetWeatherSnapshotQuery>();
+        return services;
+    }
+}

--- a/src/Sastt.Web/Pages/Aircraft/Details.cshtml
+++ b/src/Sastt.Web/Pages/Aircraft/Details.cshtml
@@ -1,0 +1,18 @@
+@page "{id:guid}"
+@model Sastt.Web.Pages.Aircraft.DetailsModel
+@{
+    ViewData["Title"] = "Aircraft Details";
+}
+
+<h1>Aircraft Details</h1>
+@if (Model.Item is not null)
+{
+    <dl>
+        <dt>Tail Number</dt><dd>@Model.Item.TailNumber</dd>
+        <dt>Model</dt><dd>@Model.Item.Model</dd>
+    </dl>
+}
+else
+{
+    <p>Aircraft not found.</p>
+}

--- a/src/Sastt.Web/Pages/Aircraft/Details.cshtml.cs
+++ b/src/Sastt.Web/Pages/Aircraft/Details.cshtml.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Aircraft;
+
+public class DetailsModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public Aircraft? Item { get; private set; }
+
+    public DetailsModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> OnGetAsync(Guid id)
+    {
+        Item = await _context.Aircraft.FindAsync(id);
+        if (Item == null)
+        {
+            return NotFound();
+        }
+        return Page();
+    }
+}

--- a/src/Sastt.Web/Pages/Aircraft/Index.cshtml
+++ b/src/Sastt.Web/Pages/Aircraft/Index.cshtml
@@ -1,0 +1,27 @@
+@page
+@model Sastt.Web.Pages.Aircraft.IndexModel
+@{
+    ViewData["Title"] = "Aircraft";
+}
+
+<h1>Aircraft</h1>
+<input id="filter" type="text" placeholder="Filter aircraft" class="form-control" />
+<table id="items" class="table">
+    <thead><tr><th>Tail Number</th><th>Model</th></tr></thead>
+    <tbody>
+@foreach (var aircraft in Model.Items)
+{
+    <tr>
+        <td><a asp-page="Details" asp-route-id="@aircraft.Id">@aircraft.TailNumber</a></td>
+        <td>@aircraft.Model</td>
+    </tr>
+}
+    </tbody>
+</table>
+
+@section Scripts {
+    <script type="module">
+        import { attachFilter } from '/js/filterWidget.js';
+        attachFilter('filter','items');
+    </script>
+}

--- a/src/Sastt.Web/Pages/Aircraft/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Aircraft/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Aircraft;
+
+public class IndexModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public IList<Aircraft> Items { get; private set; } = new List<Aircraft>();
+
+    public IndexModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Items = await _context.Aircraft.ToListAsync();
+    }
+}

--- a/src/Sastt.Web/Pages/Dashboard/Index.cshtml
+++ b/src/Sastt.Web/Pages/Dashboard/Index.cshtml
@@ -13,3 +13,13 @@ else
 {
     <p>No data available.</p>
 }
+
+<h2>Data Overview</h2>
+<ul>
+    <li><a asp-page="/Aircraft/Index">Aircraft (@Model.AircraftCount)</a></li>
+    <li><a asp-page="/WorkOrders/Index">Work Orders (@Model.WorkOrderCount)</a></li>
+    <li><a asp-page="/Tasks/Index">Tasks (@Model.TaskCount)</a></li>
+    <li><a asp-page="/Defects/Index">Defects (@Model.DefectCount)</a></li>
+    <li><a asp-page="/Pilots/Index">Pilots (@Model.PilotCount)</a></li>
+    <li><a asp-page="/TrainingSessions/Index">Training Sessions (@Model.TrainingSessionCount)</a></li>
+</ul>

--- a/src/Sastt.Web/Pages/Dashboard/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Dashboard/Index.cshtml.cs
@@ -1,22 +1,38 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using Sastt.Application.Weather;
 using Sastt.Application.Weather.Queries;
+using Sastt.Infrastructure.Persistence;
 
 namespace Sastt.Web.Pages.Dashboard;
 
 public class IndexModel : PageModel
 {
     private readonly GetWeatherSnapshotQuery _query;
+    private readonly SasttDbContext _context;
     public WeatherSnapshot? Snapshot { get; private set; }
+    public int AircraftCount { get; private set; }
+    public int WorkOrderCount { get; private set; }
+    public int TaskCount { get; private set; }
+    public int DefectCount { get; private set; }
+    public int PilotCount { get; private set; }
+    public int TrainingSessionCount { get; private set; }
 
-    public IndexModel(GetWeatherSnapshotQuery query)
+    public IndexModel(GetWeatherSnapshotQuery query, SasttDbContext context)
     {
         _query = query;
+        _context = context;
     }
 
-    public async Task OnGet()
+    public async Task OnGetAsync()
     {
         Snapshot = await _query.ExecuteAsync("YSSY");
+        AircraftCount = await _context.Aircraft.CountAsync();
+        WorkOrderCount = await _context.WorkOrders.CountAsync();
+        TaskCount = await _context.WorkOrderTasks.CountAsync();
+        DefectCount = await _context.Defects.CountAsync();
+        PilotCount = await _context.Pilots.CountAsync();
+        TrainingSessionCount = await _context.TrainingSessions.CountAsync();
     }
 }

--- a/src/Sastt.Web/Pages/Defects/Details.cshtml
+++ b/src/Sastt.Web/Pages/Defects/Details.cshtml
@@ -1,0 +1,20 @@
+@page "{id:guid}"
+@model Sastt.Web.Pages.Defects.DetailsModel
+@{
+    ViewData["Title"] = "Defect Details";
+}
+
+<h1>Defect Details</h1>
+@if (Model.Item is not null)
+{
+    <dl>
+        <dt>Description</dt><dd>@Model.Item.Description</dd>
+        <dt>Priority</dt><dd>@Model.Item.Priority</dd>
+        <dt>Resolved</dt><dd>@Model.Item.IsResolved</dd>
+        <dt>Aircraft</dt><dd>@Model.Item.AircraftId</dd>
+    </dl>
+}
+else
+{
+    <p>Defect not found.</p>
+}

--- a/src/Sastt.Web/Pages/Defects/Details.cshtml.cs
+++ b/src/Sastt.Web/Pages/Defects/Details.cshtml.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Defects;
+
+public class DetailsModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public Defect? Item { get; private set; }
+
+    public DetailsModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> OnGetAsync(Guid id)
+    {
+        Item = await _context.Defects.FindAsync(id);
+        if (Item == null)
+        {
+            return NotFound();
+        }
+        return Page();
+    }
+}

--- a/src/Sastt.Web/Pages/Defects/Index.cshtml
+++ b/src/Sastt.Web/Pages/Defects/Index.cshtml
@@ -1,0 +1,28 @@
+@page
+@model Sastt.Web.Pages.Defects.IndexModel
+@{
+    ViewData["Title"] = "Defects";
+}
+
+<h1>Defects</h1>
+<input id="filter" type="text" placeholder="Filter defects" class="form-control" />
+<table id="items" class="table">
+    <thead><tr><th>Description</th><th>Priority</th><th>Resolved</th></tr></thead>
+    <tbody>
+@foreach (var defect in Model.Items)
+{
+    <tr>
+        <td><a asp-page="Details" asp-route-id="@defect.Id">@defect.Description</a></td>
+        <td>@defect.Priority</td>
+        <td>@defect.IsResolved</td>
+    </tr>
+}
+    </tbody>
+</table>
+
+@section Scripts {
+    <script type="module">
+        import { attachFilter } from '/js/filterWidget.js';
+        attachFilter('filter','items');
+    </script>
+}

--- a/src/Sastt.Web/Pages/Defects/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Defects/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Defects;
+
+public class IndexModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public IList<Defect> Items { get; private set; } = new List<Defect>();
+
+    public IndexModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Items = await _context.Defects.ToListAsync();
+    }
+}

--- a/src/Sastt.Web/Pages/Pilots/Details.cshtml
+++ b/src/Sastt.Web/Pages/Pilots/Details.cshtml
@@ -1,0 +1,18 @@
+@page "{id:guid}"
+@model Sastt.Web.Pages.Pilots.DetailsModel
+@{
+    ViewData["Title"] = "Pilot Details";
+}
+
+<h1>Pilot Details</h1>
+@if (Model.Item is not null)
+{
+    <dl>
+        <dt>Name</dt><dd>@Model.Item.Name</dd>
+        <dt>Training Sessions</dt><dd>@Model.Item.TrainingSessions.Count</dd>
+    </dl>
+}
+else
+{
+    <p>Pilot not found.</p>
+}

--- a/src/Sastt.Web/Pages/Pilots/Details.cshtml.cs
+++ b/src/Sastt.Web/Pages/Pilots/Details.cshtml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Pilots;
+
+public class DetailsModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public Pilot? Item { get; private set; }
+
+    public DetailsModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> OnGetAsync(Guid id)
+    {
+        Item = await _context.Pilots.Include(p => p.TrainingSessions).FirstOrDefaultAsync(p => p.Id == id);
+        if (Item == null)
+        {
+            return NotFound();
+        }
+        return Page();
+    }
+}

--- a/src/Sastt.Web/Pages/Pilots/Index.cshtml
+++ b/src/Sastt.Web/Pages/Pilots/Index.cshtml
@@ -1,0 +1,26 @@
+@page
+@model Sastt.Web.Pages.Pilots.IndexModel
+@{
+    ViewData["Title"] = "Pilots";
+}
+
+<h1>Pilots</h1>
+<input id="filter" type="text" placeholder="Filter pilots" class="form-control" />
+<table id="items" class="table">
+    <thead><tr><th>Name</th></tr></thead>
+    <tbody>
+@foreach (var pilot in Model.Items)
+{
+    <tr>
+        <td><a asp-page="Details" asp-route-id="@pilot.Id">@pilot.Name</a></td>
+    </tr>
+}
+    </tbody>
+</table>
+
+@section Scripts {
+    <script type="module">
+        import { attachFilter } from '/js/filterWidget.js';
+        attachFilter('filter','items');
+    </script>
+}

--- a/src/Sastt.Web/Pages/Pilots/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Pilots/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Pilots;
+
+public class IndexModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public IList<Pilot> Items { get; private set; } = new List<Pilot>();
+
+    public IndexModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Items = await _context.Pilots.ToListAsync();
+    }
+}

--- a/src/Sastt.Web/Pages/Tasks/Details.cshtml
+++ b/src/Sastt.Web/Pages/Tasks/Details.cshtml
@@ -1,0 +1,19 @@
+@page "{id:int}"
+@model Sastt.Web.Pages.Tasks.DetailsModel
+@{
+    ViewData["Title"] = "Task Details";
+}
+
+<h1>Task Details</h1>
+@if (Model.Item is not null)
+{
+    <dl>
+        <dt>Description</dt><dd>@Model.Item.Description</dd>
+        <dt>Completed</dt><dd>@Model.Item.IsCompleted</dd>
+        <dt>Work Order</dt><dd>@Model.Item.WorkOrderId</dd>
+    </dl>
+}
+else
+{
+    <p>Task not found.</p>
+}

--- a/src/Sastt.Web/Pages/Tasks/Details.cshtml.cs
+++ b/src/Sastt.Web/Pages/Tasks/Details.cshtml.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Sastt.Domain;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Tasks;
+
+public class DetailsModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public WorkOrderTask? Item { get; private set; }
+
+    public DetailsModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        Item = await _context.WorkOrderTasks.FindAsync(id);
+        if (Item == null)
+        {
+            return NotFound();
+        }
+        return Page();
+    }
+}

--- a/src/Sastt.Web/Pages/Tasks/Index.cshtml
+++ b/src/Sastt.Web/Pages/Tasks/Index.cshtml
@@ -1,0 +1,27 @@
+@page
+@model Sastt.Web.Pages.Tasks.IndexModel
+@{
+    ViewData["Title"] = "Tasks";
+}
+
+<h1>Tasks</h1>
+<input id="filter" type="text" placeholder="Filter tasks" class="form-control" />
+<table id="items" class="table">
+    <thead><tr><th>Description</th><th>Completed</th></tr></thead>
+    <tbody>
+@foreach (var task in Model.Items)
+{
+    <tr>
+        <td><a asp-page="Details" asp-route-id="@task.Id">@task.Description</a></td>
+        <td>@task.IsCompleted</td>
+    </tr>
+}
+    </tbody>
+</table>
+
+@section Scripts {
+    <script type="module">
+        import { attachFilter } from '/js/filterWidget.js';
+        attachFilter('filter','items');
+    </script>
+}

--- a/src/Sastt.Web/Pages/Tasks/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Tasks/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.Tasks;
+
+public class IndexModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public IList<WorkOrderTask> Items { get; private set; } = new List<WorkOrderTask>();
+
+    public IndexModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Items = await _context.WorkOrderTasks.ToListAsync();
+    }
+}

--- a/src/Sastt.Web/Pages/TrainingSessions/Details.cshtml
+++ b/src/Sastt.Web/Pages/TrainingSessions/Details.cshtml
@@ -1,0 +1,19 @@
+@page "{id:guid}"
+@model Sastt.Web.Pages.TrainingSessions.DetailsModel
+@{
+    ViewData["Title"] = "Training Session Details";
+}
+
+<h1>Training Session Details</h1>
+@if (Model.Item is not null)
+{
+    <dl>
+        <dt>Pilot</dt><dd>@Model.Item.PilotId</dd>
+        <dt>Scheduled For</dt><dd>@Model.Item.ScheduledFor</dd>
+        <dt>Completed</dt><dd>@Model.Item.Completed</dd>
+    </dl>
+}
+else
+{
+    <p>Training session not found.</p>
+}

--- a/src/Sastt.Web/Pages/TrainingSessions/Details.cshtml.cs
+++ b/src/Sastt.Web/Pages/TrainingSessions/Details.cshtml.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.TrainingSessions;
+
+public class DetailsModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public TrainingSession? Item { get; private set; }
+
+    public DetailsModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> OnGetAsync(Guid id)
+    {
+        Item = await _context.TrainingSessions.FindAsync(id);
+        if (Item == null)
+        {
+            return NotFound();
+        }
+        return Page();
+    }
+}

--- a/src/Sastt.Web/Pages/TrainingSessions/Index.cshtml
+++ b/src/Sastt.Web/Pages/TrainingSessions/Index.cshtml
@@ -1,0 +1,28 @@
+@page
+@model Sastt.Web.Pages.TrainingSessions.IndexModel
+@{
+    ViewData["Title"] = "Training Sessions";
+}
+
+<h1>Training Sessions</h1>
+<input id="filter" type="text" placeholder="Filter sessions" class="form-control" />
+<table id="items" class="table">
+    <thead><tr><th>Pilot</th><th>Scheduled For</th><th>Completed</th></tr></thead>
+    <tbody>
+@foreach (var session in Model.Items)
+{
+    <tr>
+        <td><a asp-page="Details" asp-route-id="@session.Id">@session.PilotId</a></td>
+        <td>@session.ScheduledFor</td>
+        <td>@session.Completed</td>
+    </tr>
+}
+    </tbody>
+</table>
+
+@section Scripts {
+    <script type="module">
+        import { attachFilter } from '/js/filterWidget.js';
+        attachFilter('filter','items');
+    </script>
+}

--- a/src/Sastt.Web/Pages/TrainingSessions/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/TrainingSessions/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.TrainingSessions;
+
+public class IndexModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public IList<TrainingSession> Items { get; private set; } = new List<TrainingSession>();
+
+    public IndexModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Items = await _context.TrainingSessions.ToListAsync();
+    }
+}

--- a/src/Sastt.Web/Pages/WorkOrders/Details.cshtml
+++ b/src/Sastt.Web/Pages/WorkOrders/Details.cshtml
@@ -1,0 +1,20 @@
+@page "{id:guid}"
+@model Sastt.Web.Pages.WorkOrders.DetailsModel
+@{
+    ViewData["Title"] = "Work Order Details";
+}
+
+<h1>Work Order Details</h1>
+@if (Model.Item is not null)
+{
+    <dl>
+        <dt>Id</dt><dd>@Model.Item.Id</dd>
+        <dt>Aircraft</dt><dd>@Model.Item.AircraftId</dd>
+        <dt>Status</dt><dd>@Model.Item.Status</dd>
+        <dt>Priority</dt><dd>@Model.Item.Priority</dd>
+    </dl>
+}
+else
+{
+    <p>Work order not found.</p>
+}

--- a/src/Sastt.Web/Pages/WorkOrders/Details.cshtml.cs
+++ b/src/Sastt.Web/Pages/WorkOrders/Details.cshtml.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.WorkOrders;
+
+public class DetailsModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public WorkOrder? Item { get; private set; }
+
+    public DetailsModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> OnGetAsync(Guid id)
+    {
+        Item = await _context.WorkOrders.FindAsync(id);
+        if (Item == null)
+        {
+            return NotFound();
+        }
+        return Page();
+    }
+}

--- a/src/Sastt.Web/Pages/WorkOrders/Index.cshtml
+++ b/src/Sastt.Web/Pages/WorkOrders/Index.cshtml
@@ -1,0 +1,28 @@
+@page
+@model Sastt.Web.Pages.WorkOrders.IndexModel
+@{
+    ViewData["Title"] = "Work Orders";
+}
+
+<h1>Work Orders</h1>
+<input id="filter" type="text" placeholder="Filter work orders" class="form-control" />
+<table id="items" class="table">
+    <thead><tr><th>Id</th><th>Status</th><th>Priority</th></tr></thead>
+    <tbody>
+@foreach (var wo in Model.Items)
+{
+    <tr>
+        <td><a asp-page="Details" asp-route-id="@wo.Id">@wo.Id</a></td>
+        <td>@wo.Status</td>
+        <td>@wo.Priority</td>
+    </tr>
+}
+    </tbody>
+</table>
+
+@section Scripts {
+    <script type="module">
+        import { attachFilter } from '/js/filterWidget.js';
+        attachFilter('filter','items');
+    </script>
+}

--- a/src/Sastt.Web/Pages/WorkOrders/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/WorkOrders/Index.cshtml.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Domain.Entities;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Pages.WorkOrders;
+
+public class IndexModel : PageModel
+{
+    private readonly SasttDbContext _context;
+    public IList<WorkOrder> Items { get; private set; } = new List<WorkOrder>();
+
+    public IndexModel(SasttDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task OnGetAsync()
+    {
+        Items = await _context.WorkOrders.ToListAsync();
+    }
+}

--- a/src/Sastt.Web/Program.cs
+++ b/src/Sastt.Web/Program.cs
@@ -1,16 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application;
 using Sastt.Application.Weather;
-using Sastt.Application.Weather.Queries;
+using Sastt.Infrastructure.Persistence;
 using Sastt.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Services.AddApplication();
 builder.Services.AddRazorPages();
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient<IWeatherClient, WeatherClient>();
-builder.Services.AddScoped<GetWeatherSnapshotQuery>();
+builder.Services.AddDbContext<SasttDbContext>(options =>
+    options.UseInMemoryDatabase("SasttDb"));
 
 var app = builder.Build();
 
+app.UseStaticFiles();
 app.MapRazorPages();
 
 

--- a/src/Sastt.Web/Sastt.Web.csproj
+++ b/src/Sastt.Web/Sastt.Web.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="../Sastt.Application/Sastt.Application.csproj" />
     <ProjectReference Include="../Sastt.Infrastructure/Sastt.Infrastructure.csproj" />
     <ProjectReference Include="../Sastt.Domain/Sastt.Domain.csproj" />
 

--- a/src/Sastt.Web/wwwroot/js/filterWidget.js
+++ b/src/Sastt.Web/wwwroot/js/filterWidget.js
@@ -1,0 +1,12 @@
+export function attachFilter(inputId, tableId) {
+    const input = document.getElementById(inputId);
+    const table = document.getElementById(tableId);
+    if (!input || !table) return;
+    input.addEventListener('keyup', () => {
+        const filter = input.value.toLowerCase();
+        Array.from(table.getElementsByTagName('tr')).forEach(row => {
+            const text = (row.textContent || '').toLowerCase();
+            row.style.display = text.includes(filter) ? '' : 'none';
+        });
+    });
+}

--- a/src/Sastt.Web/wwwroot/js/filterWidget.ts
+++ b/src/Sastt.Web/wwwroot/js/filterWidget.ts
@@ -1,0 +1,13 @@
+export function attachFilter(inputId: string, tableId: string): void {
+    const input = document.getElementById(inputId) as HTMLInputElement | null;
+    const table = document.getElementById(tableId) as HTMLTableElement | null;
+    if (!input || !table) return;
+
+    input.addEventListener('keyup', () => {
+        const filter = input.value.toLowerCase();
+        Array.from(table.getElementsByTagName('tr')).forEach(row => {
+            const text = row.textContent?.toLowerCase() ?? '';
+            row.style.display = text.includes(filter) ? '' : 'none';
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- Register application services and EF Core context via dependency injection
- Add Razor Pages for aircraft, work orders, tasks, defects, pilots, and training sessions with list/detail views and filtering
- Introduce TypeScript filter widget and enhanced dashboard with entity counts

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

