### PR TITLE
Implement weather client with caching and dashboard snapshot

### DIFF
--- a/src/Sastt.Application/Weather/Queries/GetWeatherSnapshotQuery.cs
+++ b/src/Sastt.Application/Weather/Queries/GetWeatherSnapshotQuery.cs
@@ -25,7 +25,11 @@ public class GetWeatherSnapshotQuery
         }
 
         snapshot = await _client.GetWeatherAsync(baseCode, cancellationToken);
-        _cache.Set(cacheKey, snapshot, CacheDuration);
+        var options = new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = CacheDuration
+        };
+        _cache.Set(cacheKey, snapshot, options);
         return snapshot;
     }
 }

--- a/src/Sastt.Infrastructure/Services/WeatherClient.cs
+++ b/src/Sastt.Infrastructure/Services/WeatherClient.cs
@@ -20,21 +20,29 @@ public class WeatherClient : IWeatherClient
 
     public async Task<WeatherSnapshot> GetWeatherAsync(string baseCode, CancellationToken cancellationToken = default)
     {
-        var url = $"https://api.open-meteo.com/v1/forecast?latitude=0&longitude=0&current_weather=true&apikey={_apiKey}";
-        var result = await _httpClient.GetFromJsonAsync<OpenMeteoResponse>(url, cancellationToken);
-        var temp = result?.CurrentWeather?.Temperature ?? 0m;
-        var cond = result?.CurrentWeather?.WeatherCode?.ToString() ?? "Unknown";
+        // WeatherAPI endpoint (https://www.weatherapi.com/)
+        var url = $"https://api.weatherapi.com/v1/current.json?key={_apiKey}&q={baseCode}&aqi=no";
+        var result = await _httpClient.GetFromJsonAsync<WeatherApiResponse>(url, cancellationToken);
+
+        var temp = result?.Current?.TempC ?? 0m;
+        var cond = result?.Current?.Condition?.Text ?? "Unknown";
+
         return new WeatherSnapshot(baseCode, temp, cond, DateTime.UtcNow);
     }
 
-    private sealed class OpenMeteoResponse
+    private sealed class WeatherApiResponse
     {
-        public CurrentWeatherInfo? CurrentWeather { get; set; }
+        public CurrentWeather? Current { get; set; }
     }
 
-    private sealed class CurrentWeatherInfo
+    private sealed class CurrentWeather
     {
-        public decimal Temperature { get; set; }
-        public int WeatherCode { get; set; }
+        public decimal TempC { get; set; }
+        public Condition? Condition { get; set; }
+    }
+
+    private sealed class Condition
+    {
+        public string? Text { get; set; }
     }
 }

--- a/src/Sastt.Web/Pages/Dashboard/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Dashboard/Index.cshtml.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
 using Sastt.Application.Weather;
 using Sastt.Application.Weather.Queries;
 
@@ -8,15 +9,17 @@ namespace Sastt.Web.Pages.Dashboard;
 public class IndexModel : PageModel
 {
     private readonly GetWeatherSnapshotQuery _query;
+    private readonly string _defaultBase;
     public WeatherSnapshot? Snapshot { get; private set; }
 
-    public IndexModel(GetWeatherSnapshotQuery query)
+    public IndexModel(GetWeatherSnapshotQuery query, IConfiguration config)
     {
         _query = query;
+        _defaultBase = config["APP__DEFAULTBASE"] ?? "YSSY";
     }
 
     public async Task OnGet()
     {
-        Snapshot = await _query.ExecuteAsync("YSSY");
+        Snapshot = await _query.ExecuteAsync(_defaultBase);
     }
 }


### PR DESCRIPTION
## Summary
- Use WeatherAPI via HttpClient for weather snapshots using configured API key
- Cache snapshots for 15 minutes with in-memory cache
- Show weather on dashboard using configured default base

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad2935888329954baa43afacac48