### PR TITLE
Add CSV and PDF report generation

### DIFF
--- a/src/Sastt.Application/Reports/TrainingReportService.cs
+++ b/src/Sastt.Application/Reports/TrainingReportService.cs
@@ -1,0 +1,65 @@
+using System.Text;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using Sastt.Domain;
+
+namespace Sastt.Application.Reports;
+
+public class TrainingReportService
+{
+    public byte[] GenerateCsv(IEnumerable<TrainingSession> sessions)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Id,Pilot,Date,Hours");
+        foreach (var session in sessions)
+        {
+            var pilot = session.Pilot?.Name ?? string.Empty;
+            sb.AppendLine($"{session.Id},{pilot},{session.Date:yyyy-MM-dd},{session.Hours}");
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    public byte[] GeneratePdf(IEnumerable<TrainingSession> sessions)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Margin(20);
+                page.Content().Table(table =>
+                {
+                    table.ColumnsDefinition(columns =>
+                    {
+                        columns.ConstantColumn(50);
+                        columns.RelativeColumn();
+                        columns.ConstantColumn(100);
+                        columns.ConstantColumn(50);
+                    });
+
+                    table.Header(header =>
+                    {
+                        header.Cell().Element(CellStyle).Text("Id");
+                        header.Cell().Element(CellStyle).Text("Pilot");
+                        header.Cell().Element(CellStyle).Text("Date");
+                        header.Cell().Element(CellStyle).Text("Hours");
+                    });
+
+                    foreach (var session in sessions)
+                    {
+                        table.Cell().Element(CellStyle).Text(session.Id.ToString());
+                        table.Cell().Element(CellStyle).Text(session.Pilot?.Name ?? string.Empty);
+                        table.Cell().Element(CellStyle).Text(session.Date.ToString("yyyy-MM-dd"));
+                        table.Cell().Element(CellStyle).Text(session.Hours.ToString());
+                    }
+                });
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    private static IContainer CellStyle(IContainer container)
+        => container.BorderBottom(1).BorderColor(Colors.Grey.Lighten2).PaddingVertical(5).PaddingHorizontal(2);
+}
+

--- a/src/Sastt.Application/Reports/WorkOrderReportService.cs
+++ b/src/Sastt.Application/Reports/WorkOrderReportService.cs
@@ -1,0 +1,68 @@
+using System.Text;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using Sastt.Domain;
+
+namespace Sastt.Application.Reports;
+
+public class WorkOrderReportService
+{
+    public byte[] GenerateCsv(IEnumerable<WorkOrder> workOrders)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Id,Title,Aircraft,Tasks,Defects");
+        foreach (var order in workOrders)
+        {
+            var aircraft = order.Aircraft?.TailNumber ?? string.Empty;
+            sb.AppendLine($"{order.Id},{order.Title},{aircraft},{order.Tasks.Count},{order.Defects.Count}");
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    public byte[] GeneratePdf(IEnumerable<WorkOrder> workOrders)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Margin(20);
+                page.Content().Table(table =>
+                {
+                    table.ColumnsDefinition(columns =>
+                    {
+                        columns.ConstantColumn(50);
+                        columns.RelativeColumn();
+                        columns.RelativeColumn();
+                        columns.ConstantColumn(60);
+                        columns.ConstantColumn(60);
+                    });
+
+                    table.Header(header =>
+                    {
+                        header.Cell().Element(CellStyle).Text("Id");
+                        header.Cell().Element(CellStyle).Text("Title");
+                        header.Cell().Element(CellStyle).Text("Aircraft");
+                        header.Cell().Element(CellStyle).Text("Tasks");
+                        header.Cell().Element(CellStyle).Text("Defects");
+                    });
+
+                    foreach (var order in workOrders)
+                    {
+                        table.Cell().Element(CellStyle).Text(order.Id.ToString());
+                        table.Cell().Element(CellStyle).Text(order.Title);
+                        table.Cell().Element(CellStyle).Text(order.Aircraft?.TailNumber ?? string.Empty);
+                        table.Cell().Element(CellStyle).Text(order.Tasks.Count.ToString());
+                        table.Cell().Element(CellStyle).Text(order.Defects.Count.ToString());
+                    }
+                });
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    private static IContainer CellStyle(IContainer container)
+        => container.BorderBottom(1).BorderColor(Colors.Grey.Lighten2).PaddingVertical(5).PaddingHorizontal(2);
+}
+

--- a/src/Sastt.Application/Sastt.Application.csproj
+++ b/src/Sastt.Application/Sastt.Application.csproj
@@ -5,6 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="QuestPDF" Version="2024.3.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Sastt.Domain\Sastt.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Sastt.Web/Controllers/ReportsController.cs
+++ b/src/Sastt.Web/Controllers/ReportsController.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Reports;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Web.Controllers;
+
+[Route("reports")]
+public class ReportsController : Controller
+{
+    private readonly SasttDbContext _context;
+    private readonly WorkOrderReportService _workOrders;
+    private readonly TrainingReportService _training;
+
+    public ReportsController(SasttDbContext context, WorkOrderReportService workOrders, TrainingReportService training)
+    {
+        _context = context;
+        _workOrders = workOrders;
+        _training = training;
+    }
+
+    [HttpGet("workorders/csv")]
+    public async Task<IActionResult> WorkOrdersCsv()
+    {
+        var workOrders = await _context.WorkOrders
+            .Include(w => w.Aircraft)
+            .Include(w => w.Tasks)
+            .Include(w => w.Defects)
+            .ToListAsync();
+
+        var bytes = _workOrders.GenerateCsv(workOrders);
+        return File(bytes, "text/csv", "workorders.csv");
+    }
+
+    [HttpGet("workorders/pdf")]
+    public async Task<IActionResult> WorkOrdersPdf()
+    {
+        var workOrders = await _context.WorkOrders
+            .Include(w => w.Aircraft)
+            .Include(w => w.Tasks)
+            .Include(w => w.Defects)
+            .ToListAsync();
+
+        var bytes = _workOrders.GeneratePdf(workOrders);
+        return File(bytes, "application/pdf", "workorders.pdf");
+    }
+
+    [HttpGet("trainingsessions/csv")]
+    public async Task<IActionResult> TrainingCsv()
+    {
+        var sessions = await _context.TrainingSessions
+            .Include(t => t.Pilot)
+            .ToListAsync();
+
+        var bytes = _training.GenerateCsv(sessions);
+        return File(bytes, "text/csv", "trainingsessions.csv");
+    }
+
+    [HttpGet("trainingsessions/pdf")]
+    public async Task<IActionResult> TrainingPdf()
+    {
+        var sessions = await _context.TrainingSessions
+            .Include(t => t.Pilot)
+            .ToListAsync();
+
+        var bytes = _training.GeneratePdf(sessions);
+        return File(bytes, "application/pdf", "trainingsessions.pdf");
+    }
+}
+

--- a/src/Sastt.Web/Pages/Reports/Index.cshtml
+++ b/src/Sastt.Web/Pages/Reports/Index.cshtml
@@ -1,0 +1,10 @@
+@page
+@model Sastt.Web.Pages.Reports.IndexModel
+
+<h2>Reports</h2>
+<ul>
+    <li><a href="/reports/workorders/csv">Work Orders (CSV)</a></li>
+    <li><a href="/reports/workorders/pdf">Work Orders (PDF)</a></li>
+    <li><a href="/reports/trainingsessions/csv">Training Sessions (CSV)</a></li>
+    <li><a href="/reports/trainingsessions/pdf">Training Sessions (PDF)</a></li>
+</ul>

--- a/src/Sastt.Web/Pages/Reports/Index.cshtml.cs
+++ b/src/Sastt.Web/Pages/Reports/Index.cshtml.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Sastt.Web.Pages.Reports;
+
+public class IndexModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/src/Sastt.Web/Program.cs
+++ b/src/Sastt.Web/Program.cs
@@ -1,17 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Sastt.Application.Reports;
 using Sastt.Application.Weather;
 using Sastt.Application.Weather.Queries;
+using Sastt.Infrastructure.Persistence;
 using Sastt.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Services.AddControllers();
 builder.Services.AddRazorPages();
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient<IWeatherClient, WeatherClient>();
 builder.Services.AddScoped<GetWeatherSnapshotQuery>();
+builder.Services.AddScoped<WorkOrderReportService>();
+builder.Services.AddScoped<TrainingReportService>();
+builder.Services.AddDbContext<SasttDbContext>(options =>
+    options.UseInMemoryDatabase("Sastt"));
 
 var app = builder.Build();
 
+app.MapControllers();
 app.MapRazorPages();
-
 
 app.Run();

--- a/src/Sastt.Web/Sastt.Web.csproj
+++ b/src/Sastt.Web/Sastt.Web.csproj
@@ -3,8 +3,12 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="../Sastt.Infrastructure/Sastt.Infrastructure.csproj" />
     <ProjectReference Include="../Sastt.Domain/Sastt.Domain.csproj" />
+    <ProjectReference Include="../Sastt.Application/Sastt.Application.csproj" />
 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add services to build CSV and PDF summaries for work orders and training sessions
- expose report download endpoints and Razor page links
- wire up reporting services and in-memory database in web startup

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad2a37e08329bfd5260114cd5d29