### PR TITLE
Add CLI seeding with base-specific data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,16 @@
 
 1. `docker compose up -d` (spins up Oracle XE and the web app)
 2. Copy `.env.example` to `.env` and set `ORACLE__CONNECTIONSTRING`, `WEATHER__APIKEY`, and `APP__DEFAULTBASE`.
-3. The web container entrypoint runs `dotnet ef database update` and `--seed` automatically.
+3. The web container entrypoint runs `dotnet ef database update` and then `dotnet run -- --seed --base $APP__DEFAULTBASE`.
 4. Login as `admin@sastt.local` / `Passw0rd!` (dev)
+
+To seed manually outside of Docker:
+
+```bash
+dotnet run --project src/Sastt.Web -- --seed --base YSSY
+```
+
+Replace `YSSY` with `YWLM` to load Williamtown data.
 
 ---
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,8 +6,9 @@ if command -v dotnet >/dev/null 2>&1; then
   echo "Applying database migrations..."
   dotnet ef database update
 
-  echo "Seeding database..."
-  dotnet run -- --seed
+  BASE=${APP__DEFAULTBASE:-YSSY}
+  echo "Seeding database for ${BASE}..."
+  dotnet run -- --seed --base ${BASE}
 else
   echo "dotnet command not found" >&2
   exit 1

--- a/src/Sastt.Infrastructure/SeedData/DataSeeder.cs
+++ b/src/Sastt.Infrastructure/SeedData/DataSeeder.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Identity;
+using Sastt.Domain.Entities;
+using Sastt.Domain.Identity;
+using Sastt.Infrastructure.Identity;
+using Sastt.Infrastructure.Persistence;
+
+namespace Sastt.Infrastructure.SeedData;
+
+public static class DataSeeder
+{
+    public static async Task SeedAsync(SasttDbContext context, UserManager<ApplicationUser> userManager, string baseCode)
+    {
+        switch (baseCode.ToUpperInvariant())
+        {
+            case "YSSY":
+                await SeedBaseAsync(context, userManager, YssySeed.Aircraft, YssySeed.Pilots, YssySeed.Technicians);
+                break;
+            case "YWLM":
+                await SeedBaseAsync(context, userManager, YwlmSeed.Aircraft, YwlmSeed.Pilots, YwlmSeed.Technicians);
+                break;
+            default:
+                throw new ArgumentException("Base must be YSSY or YWLM", nameof(baseCode));
+        }
+
+        await context.SaveChangesAsync();
+    }
+
+    private static async Task SeedBaseAsync(
+        SasttDbContext context,
+        UserManager<ApplicationUser> userManager,
+        (string TailNumber, string Model)[] aircraft,
+        string[] pilots,
+        string[] technicians)
+    {
+        foreach (var (tail, model) in aircraft)
+        {
+            if (!context.Aircraft.Any(a => a.TailNumber == tail))
+            {
+                context.Aircraft.Add(new Aircraft { TailNumber = tail, Model = model });
+            }
+        }
+
+        foreach (var pilot in pilots)
+        {
+            if (!context.Pilots.Any(p => p.Name == pilot))
+            {
+                context.Pilots.Add(new Pilot { Name = pilot });
+            }
+        }
+
+        foreach (var techEmail in technicians)
+        {
+            var user = await userManager.FindByEmailAsync(techEmail);
+            if (user == null)
+            {
+                user = new ApplicationUser
+                {
+                    UserName = techEmail,
+                    Email = techEmail,
+                    EmailConfirmed = true
+                };
+                await userManager.CreateAsync(user, "Passw0rd!");
+                await userManager.AddToRoleAsync(user, SasttRoles.Technician);
+            }
+        }
+    }
+}
+

--- a/src/Sastt.Infrastructure/SeedData/YssySeed.cs
+++ b/src/Sastt.Infrastructure/SeedData/YssySeed.cs
@@ -1,0 +1,23 @@
+namespace Sastt.Infrastructure.SeedData;
+
+public static class YssySeed
+{
+    public static readonly (string TailNumber, string Model)[] Aircraft =
+    {
+        ("SY-001", "B738"),
+        ("SY-002", "A330")
+    };
+
+    public static readonly string[] Pilots =
+    {
+        "Alice Brown",
+        "Ben Smith"
+    };
+
+    public static readonly string[] Technicians =
+    {
+        "hemi.yssy@sastt.local",
+        "maya.yssy@sastt.local"
+    };
+}
+

--- a/src/Sastt.Infrastructure/SeedData/YwlmSeed.cs
+++ b/src/Sastt.Infrastructure/SeedData/YwlmSeed.cs
@@ -1,0 +1,23 @@
+namespace Sastt.Infrastructure.SeedData;
+
+public static class YwlmSeed
+{
+    public static readonly (string TailNumber, string Model)[] Aircraft =
+    {
+        ("WL-001", "Hawk 127"),
+        ("WL-002", "PC-21")
+    };
+
+    public static readonly string[] Pilots =
+    {
+        "Charlie Green",
+        "Dana White"
+    };
+
+    public static readonly string[] Technicians =
+    {
+        "luke.ywlm@sastt.local",
+        "zoe.ywlm@sastt.local"
+    };
+}
+

--- a/src/Sastt.Web/Program.cs
+++ b/src/Sastt.Web/Program.cs
@@ -1,13 +1,16 @@
+using CorrelationId;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Sastt.Application;
 using Sastt.Application.Weather;
 using Sastt.Application.Weather.Queries;
-using Sastt.Application;
-
+using Sastt.Domain.Identity;
+using Sastt.Infrastructure.Identity;
+using Sastt.Infrastructure.Persistence;
+using Sastt.Infrastructure.SeedData;
 using Sastt.Infrastructure.Services;
 using Serilog;
 using Serilog.Formatting.Json;
-using CorrelationId;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -19,7 +22,6 @@ builder.Host.UseSerilog((context, services, configuration) =>
         .WriteTo.Console(new JsonFormatter());
 });
 
-
 builder.Services.AddRazorPages();
 builder.Services.AddControllers();
 builder.Services.AddMemoryCache();
@@ -28,14 +30,38 @@ builder.Services.AddScoped<GetWeatherSnapshotQuery>();
 builder.Services.AddScoped<IAuditLogger, AuditLogger>();
 builder.Services.AddCorrelationId();
 
+builder.Services.AddDbContext<SasttDbContext>(options =>
+    options.UseOracle(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddIdentityInfrastructure(builder.Configuration);
+builder.Services.AddApplication();
+
 var app = builder.Build();
+
+if (args.Contains("--seed"))
+{
+    var baseIndex = Array.IndexOf(args, "--base");
+    var baseCode = baseIndex >= 0 && args.Length > baseIndex + 1 ? args[baseIndex + 1] : null;
+    if (string.IsNullOrWhiteSpace(baseCode))
+    {
+        Console.Error.WriteLine("Base is required. Use --base YSSY|YWLM.");
+        return;
+    }
+
+    using var scope = app.Services.CreateScope();
+    var context = scope.ServiceProvider.GetRequiredService<SasttDbContext>();
+    var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+    var initializer = scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>();
+    await initializer.SeedAsync();
+    await DataSeeder.SeedAsync(context, userManager, baseCode);
+    return;
+}
 
 app.UseCorrelationId();
 app.UseSerilogRequestLogging();
-
 
 app.MapRazorPages();
 
 app.Run();
 
 public partial class Program { }
+


### PR DESCRIPTION
## Summary
- add command-line parsing for `--seed --base` in web app
- seed aircraft, pilots, and technicians for YSSY and YWLM bases
- document seeding usage and pass base flag via entrypoint

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

